### PR TITLE
SHIN-22 Video functionality broken cuz of missing user ID

### DIFF
--- a/server.js
+++ b/server.js
@@ -87,10 +87,10 @@ io.on('connection', socket => {
     //default username
     socket.username = "Anonymous"
 
-    socket.on('join_room', (username, roomid, socketid) => {
+    socket.on('join_room', (user, roomid, socketid,peerId) => {
 	  socket.join(roomid)
-	  userJoin(username,socketid,roomid)
-	  socket.to(roomid).broadcast.emit('user_connected', username)
+	  userJoin(user.name,socketid,roomid)
+	  socket.to(roomid).broadcast.emit('user_connected', user,peerId)
 	  
     })    
 


### PR DESCRIPTION
Changed what is being sent on the 'user_connected' event from chat.js to include the full user object (instead of just the username) and the peerId. This peerId is used in the connectToNewUser function in chat.js when adding the video stream. 